### PR TITLE
Travis: Do not explicitly request Linux distribution, explicitly demand MySQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: "perl"
 perl:
   - "5.10"
 
-dist: trusty
 sudo: required
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ perl:
 sudo: required
 services:
   - docker
+  - mysql
 
 addons:
   apt:


### PR DESCRIPTION
Part 1 is for consistency with the other eHive repositories, which use the default distro.
Part 2 might become relevant once the default disto has changed from Trusty to Xenial, which does not start services such as MySQL unless told to.