### PR TITLE
Misc. Docker updates

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,21 @@
 # This is a Dockerfile to extend the basic eHive image with the modules to
 # work under Docker Swarm
 
+# 1. Get the current ensembl-hive-docker-swarm repo and remove stuff we don't want
+FROM alpine:3.9.4 AS repo
+RUN apk add git
+ADD . /tmp/ensembl-hive-docker-swarm
+# git clean will remove things listed in .gitignore, incl. .pyc, .jar etc
+# but will leave local modifications and other files, thus allowing local tests
+RUN cd /tmp/ensembl-hive-docker-swarm && git clean -d -X -f
+RUN rm -rf /tmp/ensembl-hive-docker-swarm/.git
+
+
+# 2. Make the real image
 FROM ensemblorg/ensembl-hive
 
-# Clone the repo
-ADD . /repo/ensembl-hive-docker-swarm
+# Copy the repo
+COPY --from=repo /tmp/ensembl-hive-docker-swarm /repo/ensembl-hive-docker-swarm
 
 # Currently there are no Perl dependencies
 #RUN /repo/ensembl-hive/docker/setup_cpan.Ubuntu-16.04.sh /repo/ensembl-hive-docker-swarm

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 FROM ensemblorg/ensembl-hive
 
 # Clone the repo
-RUN git clone -b master https://github.com/Ensembl/ensembl-hive-docker-swarm.git /repo/ensembl-hive-docker-swarm
+ADD . /repo/ensembl-hive-docker-swarm
 
 # Install all the dependencies
 RUN  /repo/ensembl-hive/docker/setup_cpan.Ubuntu-16.04.sh /repo/ensembl-hive-docker-swarm
@@ -13,5 +13,5 @@ RUN  /repo/ensembl-hive/docker/setup_cpan.Ubuntu-16.04.sh /repo/ensembl-hive-doc
 ENV PERL5LIB "/repo/ensembl-hive-docker-swarm/modules:$PERL5LIB"
 
 # Setup eHive (image name, and installation path)
-COPY hive_config.json /root/.hive_config.json
+COPY docker/hive_config.json /root/.hive_config.json
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,8 +6,8 @@ FROM ensemblorg/ensembl-hive
 # Clone the repo
 ADD . /repo/ensembl-hive-docker-swarm
 
-# Install all the dependencies
-RUN  /repo/ensembl-hive/docker/setup_cpan.Ubuntu-16.04.sh /repo/ensembl-hive-docker-swarm
+# Currently there are no Perl dependencies
+#RUN /repo/ensembl-hive/docker/setup_cpan.Ubuntu-16.04.sh /repo/ensembl-hive-docker-swarm
 
 # Expand PERL5LIB
 ENV PERL5LIB "/repo/ensembl-hive-docker-swarm/modules:$PERL5LIB"


### PR DESCRIPTION
Following Ensembl/ensembl-hive#137 `git` is not installed in the image any more. I have transformed the `git clone` into a separate build stage, which involves changing the build context to the root of the repo. An added benefit is that `.git` can be removed.

I have also commented out the step that installs the Perl dependencies of this repo since there are none at the moment.