### PR TITLE
Yearly copyright update - 2022

### DIFF
--- a/modules/Bio/EnsEMBL/Hive/Meadow/DockerSwarm.pm
+++ b/modules/Bio/EnsEMBL/Hive/Meadow/DockerSwarm.pm
@@ -11,7 +11,7 @@ Bio::EnsEMBL::Hive::Meadow::DockerSwarm
 =head1 LICENSE
 
     Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-    Copyright [2016-2017] EMBL-European Bioinformatics Institute
+    Copyright [2016-2022] EMBL-European Bioinformatics Institute
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/scripts/docker_jobs.pl
+++ b/scripts/docker_jobs.pl
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 # Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-# Copyright [2016-2017] EMBL-European Bioinformatics Institute
+# Copyright [2016-2022] EMBL-European Bioinformatics Institute
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Copyright update for 2022
Tests failing because of master/main branch renaming. Will run tests again after that change is merged.