### PR TITLE
Deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 Docker Swarm Meadow for eHive
 ==============================
 
+> [!IMPORTANT]  
+> As per eHive version 2.7.0, all the meadows other than `SLURM` and `Local` are deprecated and not supported anymore.
+> This repository should remain in sync with eHive's `version/2.6`, as we do not plan to apply any change to it.
+> `main` branch will instead get out of sync, because of the changes we apply to eHive's.
+> Please, do not hesitate to contact us, should this be a problem.
+
 [eHive](https://github.com/Ensembl/ensembl-hive) is a system for running computation pipelines on distributed computing resources - clusters, farms or grids.
 This repository is the implementation of eHive's _Meadow_ interface for the [Docker Swarm](https://docs.docker.com/engine/swarm/swarm-tutorial/) container orchestrator.
 
@@ -10,9 +16,9 @@ Version numbering and compatibility
 
 This repository is versioned the same way as eHive itself, and both
 checkouts are expected to be on the same branch name to function properly.
-* `version/2.5`, `version/2.6`, etc. are stable branchs that work with eHive's
+* `version/2.5`, `version/2.6`, etc. are stable branches that work with eHive's
   branches of the same name. These branches are _stable_ and _only_ receive bugfixes.
-* `master` is the development branch and follows eHive's `master`. We
+* `main` is the development branch and follows eHive's `main`. We
   primarily maintain eHive, so both repos may sometimes go out of sync
   until we upgrade the DockerSwarm module too
 
@@ -33,7 +39,7 @@ Contact us
 ----------
 
 eHive is maintained by the [Ensembl](http://www.ensembl.org/info/about/) project.
-We (Ensembl) are only using Platform LSF to run our computation
+We (Ensembl) are only using SLURM to run our computation
 pipelines, and have only tried Docker Swarm on toy examples.
 
 There is eHive users' mailing list for questions, suggestions, discussions and announcements.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Docker Swarm Meadow for eHive
 > [!IMPORTANT]  
 > As per eHive version 2.7.0, all the meadows other than `SLURM` and `Local` are deprecated and not supported anymore.
 > This repository should remain in sync with eHive's `version/2.6`, as we do not plan to apply any change to it.
-> `main` branch will instead get out of sync, because of the changes we apply to eHive's.
+> The `main` branch is expected to go out of sync over time as we apply changes to eHive.
+>
 > Please, do not hesitate to contact us, should this be a problem.
 
 [eHive](https://github.com/Ensembl/ensembl-hive) is a system for running computation pipelines on distributed computing resources - clusters, farms or grids.


### PR DESCRIPTION
At EMBL-EBI, we transitioned to use SLURM instead of LSF as job scheduling system.
We have also decided to deprecate all the meadows other than `SLURM` and `Local`, as they have never been used for production or fully developed/tested.